### PR TITLE
use new API

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,27 +9,35 @@ class GenerateAssetWebpackPlugin {
     }
 
     apply(compiler) {
-        compiler.plugin('emit', (compilation, cb) => {
-            this.fn(compilation, (err, body) => {
-                if (err) {
-                    return cb(err);
-                }
-
-                compilation.assets[this.filename] = {
-                    source: () => body,
-                    size: () => body.length
-                }
-
-                this.files.forEach(file => {
-                    compilation.assets[file] = {
-                        source: () => fs.readFileSync(file),
-                        size: () => fs.statSync(file).size
+            compiler.hooks.emit.tap('emit', function (compilation, cb) {
+                _this.fn(compilation, function (err, body) {
+                    if (err) {
+                        return cb(err);
                     }
+        
+                    compilation.assets[_this.filename] = {
+                        source: function source() {
+                            return body;
+                        },
+                        size: function size() {
+                            return body.length;
+                        }
+                    };
+        
+                    _this.files.forEach(function (file) {
+                        compilation.assets[file] = {
+                            source: function source() {
+                                return fs.readFileSync(file);
+                            },
+                            size: function size() {
+                                return fs.statSync(file).size;
+                            }
+                        };
+                    });
+        
+                    cb();
                 });
-
-                cb();
             });
-        });
     }
 
 }


### PR DESCRIPTION
reason: DeprecationWarning: Tapable.plugin is deprecated. Use new API on .hooks instead emit